### PR TITLE
Add a Debian fixture without the Suite field

### DIFF
--- a/debian/conf/distributions
+++ b/debian/conf/distributions
@@ -4,3 +4,8 @@ Architectures: armeb ppc64
 Components: asgard jotunheimr
 UdebComponents: asgard
 SignWith: 6EDF301256480B9B801EBA3D05A5E6DA269D9D98
+
+codename: nosuite
+Architectures: ppc64
+Components: asgard
+SignWith: 6EDF301256480B9B801EBA3D05A5E6DA269D9D98

--- a/debian/gen-fixtures.sh
+++ b/debian/gen-fixtures.sh
@@ -47,6 +47,7 @@ mkdir jotunheimr
 cp -a "${SRCDIR}/conf" .
 reprepro -C asgard includeudeb ragnarok asgard_udebs/*.udeb
 reprepro -C asgard includedeb ragnarok asgard/*.deb
+reprepro -C asgard includedeb nosuite asgard/*.deb
 reprepro -C jotunheimr includedeb ragnarok jotunheimr/*.deb
 
 rm dists/ragnarok/jotunheimr/binary-armeb/Packages


### PR DESCRIPTION
Adds the `nosuite` distribution to the Debian fixtures.
As the name implies this distribution does not contain the optional `Suite` field in its Release file.
This will form the basis for a test to ensure `pulp_deb` can synchronize such a repository.