### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/fixtures/
+/gnupghome/
+/.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,7 @@ RUN dnf -y install \
 
 ADD . /pulp-fixtures
 
-# for now, skip making docker fixtures
-RUN echo "" > pulp-fixtures/docker/gen-fixtures.sh
-
-RUN make -C pulp-fixtures fixtures
+RUN make -C pulp-fixtures all-fedora
 
 # === Build fixtures (Debian) =================================================
 FROM debian:stretch AS debian-build
@@ -32,7 +29,7 @@ ADD Makefile /pulp-fixtures
 ADD common /pulp-fixtures/common
 ADD debian /pulp-fixtures/debian
 
-RUN make -C pulp-fixtures fixtures/debian fixtures/debian-invalid
+RUN make -C pulp-fixtures all-debian
 
 # === Serve content ===========================================================
 FROM nginx AS server


### PR DESCRIPTION
The main reason I did this is to prevent build artifacts of local invocations of `make` from influencing the container build. (The Dockerfile copies the entire repository into the build container including any local build artifacts.)

All the refactoring of the Makefile is just a simple consequence of the primary aim. Since I excluded the `fixtures` folder from being added to the container image, I needed the `make` build to be independent of the existence of this folder.