### PR TITLE
Complex deb distributions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ all-skipped: \
 all-debian: \
 	fixtures/debian \
 	fixtures/debian-invalid \
+	fixtures/debian-complex-dists \
 
 all-fedora: \
 	fixtures/drpm-signed \
@@ -220,6 +221,9 @@ fixtures/debian: fixtures gnupghome
 
 fixtures/debian-invalid: fixtures fixtures/debian
 	debian/gen-invalid-fixtures.sh $@
+
+fixtures/debian-complex-dists: fixtures gnupghome
+	GNUPGHOME=$$(realpath -e gnupghome) debian/gen_complex_dists_fixtures.sh $@
 
 fixtures/docker: fixtures
 	docker/gen-fixtures.sh $@

--- a/debian/complex_dists_conf/distributions
+++ b/debian/complex_dists_conf/distributions
@@ -8,3 +8,12 @@ Components: asgard jotunheimr
 FakeComponentPrefix: updates
 Description: A fixtures repo with a structure modeled on debian-security.
 SignWith: 6EDF301256480B9B801EBA3D05A5E6DA269D9D98
+
+Origin: pulp-fixtures
+Label: Ubuntu-backports-like-fixture
+Suite: ragnarok-backports
+Version: 18.04
+Codename: ragnarok-backports
+Architectures: armeb ppc64
+Components: asgard jotunheimr
+Description: A fixtures repo with a structure modeled on an ubuntu-backports release.

--- a/debian/complex_dists_conf/distributions
+++ b/debian/complex_dists_conf/distributions
@@ -1,0 +1,10 @@
+Origin: pulp-fixtures
+Label: Debian-security-like-fixture
+Suite: stable
+Version: 10
+Codename: ragnarok/updates
+Architectures: armeb ppc64
+Components: asgard jotunheimr
+FakeComponentPrefix: updates
+Description: A fixtures repo with a structure modeled on debian-security.
+SignWith: 6EDF301256480B9B801EBA3D05A5E6DA269D9D98

--- a/debian/gen_complex_dists_fixtures.sh
+++ b/debian/gen_complex_dists_fixtures.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -eux
+
+SRCDIR=$(readlink -f "$(dirname "$0")")
+TMPDIR=$(mktemp -d)
+OUTPUTDIR=$(realpath "${SRCDIR}/../$1")
+
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+cd "${TMPDIR}"
+
+mkdir asgard
+(
+  cd asgard
+
+  for CTL in "${SRCDIR}"/asgard/*.ctl
+  do
+    equivs-build --arch ppc64 "${CTL}"
+  done
+)
+
+mkdir jotunheimr
+(
+  cd jotunheimr
+
+  for CTL in "${SRCDIR}"/jotunheimr/*.ctl
+  do
+    equivs-build --arch armeb "${CTL}"
+  done
+)
+
+COMMON_REPREPRO_OPTIONS=(
+  --confdir
+  "${SRCDIR}/complex_dists_conf"
+)
+
+# Create the Debian security like repo fixture:
+reprepro "${COMMON_REPREPRO_OPTIONS[@]}" -C asgard includedeb ragnarok/updates asgard/*.deb
+reprepro "${COMMON_REPREPRO_OPTIONS[@]}" -C jotunheimr includedeb ragnarok/updates jotunheimr/*.deb
+
+mkdir -p "${OUTPUTDIR}"
+cp -r --no-preserve=mode --reflink=auto "${TMPDIR}"/dists -t "${OUTPUTDIR}"
+cp -r --no-preserve=mode --reflink=auto "${TMPDIR}"/pool -t "${OUTPUTDIR}"

--- a/debian/gen_complex_dists_fixtures.sh
+++ b/debian/gen_complex_dists_fixtures.sh
@@ -39,6 +39,18 @@ COMMON_REPREPRO_OPTIONS=(
 reprepro "${COMMON_REPREPRO_OPTIONS[@]}" -C asgard includedeb ragnarok/updates asgard/*.deb
 reprepro "${COMMON_REPREPRO_OPTIONS[@]}" -C jotunheimr includedeb ragnarok/updates jotunheimr/*.deb
 
+# Also create the Ubuntu backports like repo fixture:
+reprepro "${COMMON_REPREPRO_OPTIONS[@]}" -C asgard includedeb ragnarok-backports asgard/*.deb
+reprepro "${COMMON_REPREPRO_OPTIONS[@]}" -C jotunheimr includedeb ragnarok-backports jotunheimr/*.deb
+
+RAGNAROK_BACKPORTS_RELEASE_FILE="${TMPDIR}/dists/ragnarok-backports/Release"
+
+# Actually alter the Codename in the release file like Ubuntu does:
+sed -i "s/Codename: ragnarok-backports/Codename: ragnarok/g" "${RAGNAROK_BACKPORTS_RELEASE_FILE}"
+
+# Now sign the Ubuntu like fixtures using an external singing script:
+"${SRCDIR}/sign_deb_release.sh" "${RAGNAROK_BACKPORTS_RELEASE_FILE}"
+
 mkdir -p "${OUTPUTDIR}"
 cp -r --no-preserve=mode --reflink=auto "${TMPDIR}"/dists -t "${OUTPUTDIR}"
 cp -r --no-preserve=mode --reflink=auto "${TMPDIR}"/pool -t "${OUTPUTDIR}"

--- a/debian/sign_deb_release.sh
+++ b/debian/sign_deb_release.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+RELEASE_FILE="${1}"
+OUTPUT_DIR="$(dirname "${1}")"
+DETACHED_SIGNATURE_PATH="${OUTPUT_DIR}/Release.gpg"
+INLINE_SIGNATURE_PATH="${OUTPUT_DIR}/InRelease"
+
+GPG_KEY_ID="Pulp QE"
+
+COMMON_GPG_OPTS=(
+  --batch
+  --armor
+  --digest-algo
+  SHA256
+)
+
+# Create a detached signature
+/usr/bin/gpg "${COMMON_GPG_OPTS[@]}" \
+  --detach-sign \
+  --output "${DETACHED_SIGNATURE_PATH}" \
+  --local-user "${GPG_KEY_ID}" \
+  "${RELEASE_FILE}"
+
+# Create an inline signature
+/usr/bin/gpg "${COMMON_GPG_OPTS[@]}" \
+  --clearsign \
+  --output "${INLINE_SIGNATURE_PATH}" \
+  --local-user "${GPG_KEY_ID}" \
+  "${RELEASE_FILE}"


### PR DESCRIPTION
Adds fixtures for repositories stuctured like debian-security and ubuntu-backports.
These two repositories cover the most common cases of APT repositories with a non standard distribution path, which demands test coverage.