### PR TITLE
New fixtures for RPM advisories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ all-fedora: \
 	fixtures/file-perf \
 	fixtures/file-mixed \
 	fixtures/python-pypi \
+	fixtures/rpm-advisory-diffpkgs \
 	fixtures/rpm-kickstart \
 	fixtures/rpm-with-non-utf-8 \
 	fixtures/rpm-alt-layout \
@@ -187,6 +188,7 @@ all-fedora: \
 	fixtures/rpm-unsigned \
 	fixtures/rpm-packages-updateinfo \
 	fixtures/rpm-updated-updateinfo \
+	fixtures/rpm-updated-updateversion \
 	fixtures/rpm-with-non-ascii \
 	fixtures/rpm-with-sha-512 \
 	fixtures/rpm-with-sha-1-modular \
@@ -260,6 +262,9 @@ fixtures/ostree: fixtures
 
 fixtures/python-pypi: fixtures
 	python/gen-pypi-repo.sh $@ python/pypi-assets $(base_url)
+
+fixtures/rpm-advisory-diffpkgs: fixtures
+	rpm/gen-patched-fixtures.sh $@ rpm/advisory-diffpkgs.patch
 
 fixtures/rpm-kickstart: fixtures
 	cp -R ./rpm/assets-kickstart ./fixtures/rpm-kickstart
@@ -337,6 +342,9 @@ fixtures/rpm-richnweak-deps: fixtures/srpm-richnweak-deps fixtures
 
 fixtures/rpm-updated-updateinfo: fixtures
 	rpm/gen-patched-fixtures.sh $@ rpm/updated-updateinfo.patch
+
+fixtures/rpm-updated-updateversion: fixtures
+	rpm/gen-patched-fixtures.sh $@ rpm/updated-updateversion.patch
 
 fixtures/rpm-with-modules: fixtures
 	rpm/gen-patched-fixtures.sh $@ rpm/modules-updateinfo.patch

--- a/rpm/advisory-diffpkgs.patch
+++ b/rpm/advisory-diffpkgs.patch
@@ -1,0 +1,23 @@
+--- a/rpm/assets/updateinfo.xml
++++ b/rpm/assets/updateinfo.xml
+@@ -33,14 +33,14 @@
+   <pkglist>
+     <collection short="">
+       <name>1</name>
+-      <package arch="noarch" name="crow" release="1" src="http://www.fedoraproject.org" version="0.8">
+-        <filename>crow-0.8-1.noarch.rpm</filename>
++      <package arch="noarch" name="walrus" release="1" src="http://www.fedoraproject.org" version="5.21">
++        <filename>walrus-5.21-1.noarch.rpm</filename>
+       </package>
+-      <package arch="noarch" name="stork" release="2" src="http://www.fedoraproject.org" version="0.12">
+-        <filename>stork-0.12-2.noarch.rpm</filename>
++      <package arch="noarch" name="penguin" release="1" src="http://www.fedoraproject.org" version="0.9.1">
++        <filename>penguin-0.9.1-1.noarch.rpm</filename>
+       </package>
+-      <package arch="noarch" name="duck" release="1" src="http://www.fedoraproject.org" version="0.6">
+-        <filename>duck-0.6-1.noarch.rpm</filename>
++      <package arch="noarch" name="shark" release="1" src="http://www.fedoraproject.org" version="0.1">
++        <filename>shark-0.1-1.noarch.rpm</filename>
+       </package>
+     </collection>
+   </pkglist>

--- a/rpm/updated-updateversion.patch
+++ b/rpm/updated-updateversion.patch
@@ -1,0 +1,11 @@
+--- a/rpm/assets/updateinfo.xml
++++ b/rpm/assets/updateinfo.xml
+@@ -23,7 +23,7 @@
+   </pkglist>
+ </update>
+ 
+-<update from="errata@redhat.com" status="stable" type="security" version="1">
++<update from="errata@redhat.com" status="stable" type="security" version="2">
+   <id>RHEA-2012:0056</id>
+   <title>Bird_Erratum</title>
+   <release>1</release>


### PR DESCRIPTION
Two new fixtures that can be generated for testing advisories.

advisory-diffpkgs - Advisory with same date, version and different
packages - merge advisories test
updated-updateversion - Advisory with same date and newer version

[noissue]