### PR TITLE
Remove any trailing slash from BASE_URL

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+STRIPPED_URL=${BASE_URL%/}
+
 # inject BASE_URL at runtime
 find /usr/share/nginx/html \( -name "*mirrorlist*" -o -name "*.html" -o -name "*.json" \) \
-  -exec sed -i -e "s%http://BASE_URL%$BASE_URL%g" {} +
+  -exec sed -i -e "s%http://BASE_URL%$STRIPPED_URL%g" {} +
 
 nginx -g 'daemon off;'


### PR DESCRIPTION
Ran into an issue where we were accidentally using `http://fixtures.pulpproject.org/` with a trailing slash.