### PR TITLE
Support for use auth token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ jobs:
         - sleep 2 # it can take a couple seconds for sed to run and nginx to boot
         - curl --fail localhost:8000/file/PULP_MANIFEST
         - curl --fail localhost:8000/debian/dists/ragnarok/Release
+        - curl -L localhost:8000/rpm-unsigned/?badtoken | grep "Wrong auth token"
+        - curl --fail -L localhost:8000/rpm-unsigned/?secret
+        - curl --fail -L localhost:8000/file-large/?parameter
         - '[[ $(curl localhost:8000/rpm-mirrorlist-good) == "http://example.com/rpm-unsigned/" ]] || exit 1'
       deploy:
         - provider: script

--- a/Containerfile
+++ b/Containerfile
@@ -38,8 +38,8 @@ RUN rm /usr/share/nginx/html/index.html
 COPY --from=fedora-build pulp-fixtures/fixtures /usr/share/nginx/html
 COPY --from=debian-build pulp-fixtures/fixtures /usr/share/nginx/html
 
-# turn on autoindex
-RUN sed -i -e '/location \/ {/a autoindex on\;' /etc/nginx/conf.d/default.conf
+# use custom nginx.conf
+COPY common/nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 80
 

--- a/common/nginx.conf
+++ b/common/nginx.conf
@@ -1,0 +1,59 @@
+# Custom nginx.conf for pulp-fixtures container
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    # remove parameters from original URL
+    map $request_uri $request_uri_path {
+        "~^(?P<path>[^?]*)(\?.*)?$" $path;
+    }
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        # if auth token after URL is '?secret' return
+        # address without this token (only for urls with 'rpm')
+        if ($request_uri ~ "(.+)rpm(.+)\?secret$") {
+            return 301 $scheme://$http_host$request_uri_path;
+        }
+
+        # if token doesn't match the token above raise error
+        # and return 401 UNAUTHORIZED (only for urls with 'rpm')
+        if ($request_uri ~ "(.+)rpm(.+)\?(.+)$") {
+            return 401 "Wrong auth token.";
+        }
+
+        location / {
+            autoindex on;
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }
+    # Doesn't need to include conf.d dir as needed locations are specified here
+    #include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
Removing 'sed' injections for nginx config.
Using custom nginx.conf instead.
Adding ability to use auth token (e.g. '?secret') and check for wrong tokens.
Adds two simple checks for travis. 

Now there is two ways to reach repositories.

- direct e.g. pulp-fixtures/rpm-signed/
- with auth token e.g. pulp-fixtures/rpm-signed/?secret

closes: #7004
https://pulp.plan.io/issues/7004