### PR TITLE
Fix shellcheck error regarding sh and pipefail

### DIFF
--- a/docker/gen-fixtures.sh
+++ b/docker/gen-fixtures.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # coding=utf-8
 #
 # Use `docker save` to create a tarball that can be uploaded to a Pulp Docker


### PR DESCRIPTION
In POSIX sh, set option pipefail is undefined.