### PR TITLE
Added new X-PyPI-Last-Serial header to python fixture pages

### DIFF
--- a/common/nginx.conf
+++ b/common/nginx.conf
@@ -48,6 +48,9 @@ http {
             autoindex on;
             root   /usr/share/nginx/html;
             index  index.html index.htm index.json;
+            location ~* ^/python-pypi/.*\.(html|json)$ {
+                add_header X-PyPI-Last-Serial 1000000000;
+            }
         }
         error_page   500 502 503 504  /50x.html;
         location = /50x.html {


### PR DESCRIPTION
The python plugin expects this header to be there to perform a cache check to see if it needs to update a package. Since the fixtures are always used when testing from a clean state, setting this to a high constant will make the plugin always update the package.

[noissue]