### PR TITLE
Prevent nginx from stripping port when it redirects

### DIFF
--- a/common/nginx.conf
+++ b/common/nginx.conf
@@ -31,6 +31,7 @@ http {
     server {
         listen       80;
         server_name  localhost;
+        port_in_redirect off;
 
         # if auth token after URL is '?secret' return
         # address without this token (only for urls with 'rpm')


### PR DESCRIPTION
Nginx drops the port number when it redirects ('localhost:8000/fixtures/python-pypi/simple/package' -> 'localhost/fixtures/python-pypi/simple/package/')