### PR TITLE
Redirects now keep their port number.

### DIFF
--- a/common/nginx.conf
+++ b/common/nginx.conf
@@ -31,6 +31,7 @@ http {
     server {
         listen       80;
         server_name  localhost;
+        absolute_redirect off;
 
         # if auth token after URL is '?secret' return
         # address without this token (only for urls with 'rpm')


### PR DESCRIPTION
Added setting 'absolute_redirect off' to prevent the port number from being stripped when a redirect occurs.