### PR TITLE
Send nginx logs on stdout/stderr

### DIFF
--- a/common/nginx.conf
+++ b/common/nginx.conf
@@ -5,6 +5,8 @@ worker_processes  1;
 
 pid        /tmp/nginx.pid;
 
+error_log stderr;
+
 events {
     worker_connections  1024;
 }
@@ -30,6 +32,8 @@ http {
         listen       8080;
         server_name  localhost;
         absolute_redirect off;
+
+        access_log /dev/stdout;
 
         # if auth token after URL is '?secret' return
         # address without this token (only for urls with 'rpm')


### PR DESCRIPTION
Since there is nothing, nginx do not send anything
anywhere, and so nothing appear in openshift.

[noissue]