### PR TITLE
Add different fields in deb and Package index

### DIFF
--- a/debian/conf/distributions
+++ b/debian/conf/distributions
@@ -3,12 +3,14 @@ suite: mythology
 Architectures: armeb ppc64
 Components: asgard jotunheimr
 UdebComponents: asgard
+DebOverride: override.ragnarok
 SignWith: 6EDF301256480B9B801EBA3D05A5E6DA269D9D98
 
 codename: nosuite
 Description: This is a valid Debian repository.
 Architectures: ppc64
 Components: asgard
+DebOverride: override.ragnarok
 SignWith: 6EDF301256480B9B801EBA3D05A5E6DA269D9D98
 
 codename: ginnungagap

--- a/debian/conf/override.ragnarok
+++ b/debian/conf/override.ragnarok
@@ -1,0 +1,6 @@
+* Task Æsir
+odin Task Æsir
+odin Description-md5 654ca349ba8dade6580ba77c71d67eff
+thor Task Æsir
+thor Bugs https://bilskirnir.example.com/bugs
+thor Description-md5 f5d3997e79acfeeb7a6ff4aa71ab65ac


### PR DESCRIPTION
Preparation for unit-tests in https://github.com/pulp/pulp_deb/pull/294
Originally I wanted to remove `Description` from the Package-Index, because it should not be necessary if `Description-md5` is present.
But pulp_deb does not see it this way right now :stuck_out_tongue_winking_eye: 
Also we have to add Translation files to the Metadata if I understood correctly: https://wiki.debian.org/DebianRepository/Format#Description