### PR TITLE
Add Debian 11 compatible test fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ help:
 	@echo "        Create Debian repository fixtures with missing Packages files for some architectures."
 	@echo "    fixtures/debian-flat"
 	@echo "        Create Debian repository fixtures in flat repository format."
+	@echo "    fixtures/debian-mixed"
+	@echo "        Create Debian 11 compatible repository fixtures."
 	@echo "    fixtures/docker"
 	@echo "        Create Docker fixture data."
 	@echo "    fixtures/drpm-signed"
@@ -204,6 +206,7 @@ all-debian: \
 	fixtures/debian-complex-dists \
 	fixtures/debian-missing-architecture \
 	fixtures/debian-flat \
+	fixtures/debian-mixed \
 
 all-fedora: \
 	fixtures/diff-name-same-content \
@@ -308,6 +311,9 @@ fixtures/debian-missing-architecture: fixtures gnupghome
 
 fixtures/debian-flat: fixtures
 	debian/gen-flat-repo-fixtures.sh $@
+
+fixtures/debian-mixed: fixtures gnupghome
+	GNUPGHOME=$$(realpath -e gnupghome) debian/gen-mixed-fixtures.sh $@
 
 fixtures/docker: fixtures
 	docker/gen-fixtures.sh $@

--- a/debian/asgard_mixed/baldr.ctl
+++ b/debian/asgard_mixed/baldr.ctl
@@ -1,0 +1,29 @@
+### Commented entries have reasonable defaults.
+### Uncomment to edit them.
+# Source: <source package name; defaults to package name>
+Section: misc
+Priority: optional
+# Homepage: <enter URL here; no default>
+Standards-Version: 3.9.2
+
+Package: baldr
+# Version: <enter version here; defaults to 1.0>
+# Maintainer: Your Name <yourname@example.com>
+# Pre-Depends: <comma-separated list of packages>
+# Depends: <comma-separated list of packages>
+# Recommends: <comma-separated list of packages>
+# Suggests: <comma-separated list of packages>
+# Provides: <comma-separated list of packages>
+# Replaces: <comma-separated list of packages>
+Architecture: amd64
+# Multi-Arch: <one of: foreign|same|allowed>
+# Copyright: <copyright file; defaults to GPL2>
+# Changelog: <changelog file; defaults to a generic changelog>
+# Readme: <README.Debian file; defaults to a generic one>
+# Extra-Files: <comma-separated list of additional files for the doc directory>
+# Links: <pair of space-separated paths; First is path symlink points at, second is filename of link>
+# Files: <pair of space-separated paths; First is file to include, second is destination>
+#  <more pairs, if there's more than one file to include. Notice the starting space>
+Description: Baldr
+ Baldr is a god associated with light, joy, purity, and the summer sun.
+

--- a/debian/asgard_mixed/eir.ctl
+++ b/debian/asgard_mixed/eir.ctl
@@ -1,0 +1,29 @@
+### Commented entries have reasonable defaults.
+### Uncomment to edit them.
+# Source: <source package name; defaults to package name>
+Section: misc
+Priority: optional
+# Homepage: <enter URL here; no default>
+Standards-Version: 3.9.2
+
+Package: eir
+# Version: <enter version here; defaults to 1.0>
+# Maintainer: Your Name <yourname@example.com>
+# Pre-Depends: <comma-separated list of packages>
+# Depends: <comma-separated list of packages>
+# Recommends: <comma-separated list of packages>
+# Suggests: <comma-separated list of packages>
+# Provides: <comma-separated list of packages>
+# Replaces: <comma-separated list of packages>
+Architecture: all
+# Multi-Arch: <one of: foreign|same|allowed>
+# Copyright: <copyright file; defaults to GPL2>
+# Changelog: <changelog file; defaults to a generic changelog>
+# Readme: <README.Debian file; defaults to a generic one>
+# Extra-Files: <comma-separated list of additional files for the doc directory>
+# Links: <pair of space-separated paths; First is path symlink points at, second is filename of link>
+# Files: <pair of space-separated paths; First is file to include, second is destination>
+#  <more pairs, if there's more than one file to include. Notice the starting space>
+Description: Eir
+ Eir is a valkyrie and goddess associated with medical skill.
+

--- a/debian/asgard_mixed/frigg.ctl
+++ b/debian/asgard_mixed/frigg.ctl
@@ -1,0 +1,29 @@
+### Commented entries have reasonable defaults.
+### Uncomment to edit them.
+# Source: <source package name; defaults to package name>
+Section: misc
+Priority: optional
+# Homepage: <enter URL here; no default>
+Standards-Version: 3.9.2
+
+Package: frigg
+# Version: <enter version here; defaults to 1.0>
+# Maintainer: Your Name <yourname@example.com>
+# Pre-Depends: <comma-separated list of packages>
+# Depends: <comma-separated list of packages>
+# Recommends: <comma-separated list of packages>
+# Suggests: <comma-separated list of packages>
+# Provides: <comma-separated list of packages>
+# Replaces: <comma-separated list of packages>
+Architecture: ppc64
+# Multi-Arch: <one of: foreign|same|allowed>
+# Copyright: <copyright file; defaults to GPL2>
+# Changelog: <changelog file; defaults to a generic changelog>
+# Readme: <README.Debian file; defaults to a generic one>
+# Extra-Files: <comma-separated list of additional files for the doc directory>
+# Links: <pair of space-separated paths; First is path symlink points at, second is filename of link>
+# Files: <pair of space-separated paths; First is file to include, second is destination>
+#  <more pairs, if there's more than one file to include. Notice the starting space>
+Description: Frigg
+ Frigg is described as the wife of the god Odin.
+

--- a/debian/conf/distributions
+++ b/debian/conf/distributions
@@ -18,3 +18,8 @@ Description: This repository is valid, but contains no packages!
 Architectures: armeb ppc64
 Components: asgard jotunheimr
 SignWith: 6EDF301256480B9B801EBA3D05A5E6DA269D9D98
+
+codename: muspelheim
+Architectures: amd64 armeb ppc64
+Components: asgard nidavellir
+SignWith: 6EDF301256480B9B801EBA3D05A5E6DA269D9D98

--- a/debian/gen-mixed-fixtures.sh
+++ b/debian/gen-mixed-fixtures.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -eux
+
+SRCDIR=$(readlink -f "$(dirname "$0")")
+TMPDIR=$(mktemp -d)
+OUTPUTDIR=$(realpath "${SRCDIR}/../$1")
+
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+cd "${TMPDIR}"
+
+mkdir asgard
+(
+  cd asgard
+  equivs-build --arch amd64 "${SRCDIR}/asgard_mixed/baldr.ctl"
+  equivs-build "${SRCDIR}/asgard_mixed/eir.ctl"
+  equivs-build --arch ppc64 "${SRCDIR}/asgard_mixed/frigg.ctl"
+)
+
+mkdir nidavellir
+(
+  cd nidavellir
+  equivs-build --arch amd64 "${SRCDIR}/nidavellir/hreidmar.ctl"
+  equivs-build "${SRCDIR}/nidavellir/regin.ctl"
+  equivs-build --arch ppc64 "${SRCDIR}/nidavellir/fafner.ctl"
+)
+
+cp -a "${SRCDIR}/conf" .
+reprepro -C asgard includedeb muspelheim asgard/baldr_1.0_amd64.deb
+reprepro includedeb muspelheim asgard/eir_1.0_all.deb
+reprepro -C asgard includedeb muspelheim asgard/frigg_1.0_ppc64.deb
+reprepro -C nidavellir includedeb muspelheim nidavellir/hreidmar_1.0_amd64.deb
+reprepro -C nidavellir includedeb muspelheim nidavellir/regin_1.0_all.deb
+reprepro -C nidavellir includedeb muspelheim nidavellir/fafner_1.0_ppc64.deb
+
+# Rename binary-armeb to binary-all
+mv "${TMPDIR}/dists/muspelheim/asgard/binary-armeb" "${TMPDIR}/dists/muspelheim/asgard/binary-all"
+mv "${TMPDIR}/dists/muspelheim/nidavellir/binary-armeb" "${TMPDIR}/dists/muspelheim/nidavellir/binary-all"
+
+sed -i -e "s/armeb/all/g" "${TMPDIR}/dists/muspelheim/Release"
+sed -i -e "s/armeb/all/g" "${TMPDIR}/dists/muspelheim/InRelease"
+sed -i -e "s/armeb/all/g" "${TMPDIR}/dists/muspelheim/asgard/binary-all/Release"
+sed -i -e "s/armeb/all/g" "${TMPDIR}/dists/muspelheim/nidavellir/binary-all/Release"
+
+# Add the 'No-Support-for-Architecture-all' metadata to the Release file
+sed -i "3 i No-Support-for-Architecture-all: Packages" "${TMPDIR}/dists/muspelheim/Release"
+sed -i "5 i No-Support-for-Architecture-all: Packages" "${TMPDIR}/dists/muspelheim/InRelease"
+
+# Update Release and InRelease with the new checksums and file size
+mapfile -t releases < <(grep -rl --exclude=*.db Release)
+
+components=("asgard" "nidavellir")
+
+for release in "${releases[@]}"; do
+  for component in "${components[@]}"; do
+    md5=$(md5sum "${TMPDIR}/dists/muspelheim/${component}/binary-all/Release" | awk '{print $1}')
+    sha1=$(sha1sum "${TMPDIR}/dists/muspelheim/${component}/binary-all/Release" | awk '{print $1}')
+    sha256=$(sha256sum "${TMPDIR}/dists/muspelheim/${component}/binary-all/Release" | awk '{print $1}')
+    checksums=("${md5}" "${sha1}" "${sha256}")
+    filesize=$(find "${TMPDIR}/dists/muspelheim/${component}/binary-all/Release" -print0 | xargs stat -c "%s")
+    mapfile -t lines < <(grep -n "${component}/binary-all/Release" "${TMPDIR}/${release}" | cut -d : -f 1)
+
+    i=0
+    for line in "${lines[@]}"; do
+      sed -i "${line}s/.*/ ${checksums[i]} ${filesize} ${component}\/binary-all\/Release/" "${TMPDIR}/${release}"
+      ((i = i + 1))
+    done
+  done
+done
+
+mkdir -p "${OUTPUTDIR}"
+cp -r --no-preserve=mode --reflink=auto "${TMPDIR}"/dists -t "${OUTPUTDIR}"
+cp -r --no-preserve=mode --reflink=auto "${TMPDIR}"/pool -t "${OUTPUTDIR}"

--- a/debian/nidavellir/fafner.ctl
+++ b/debian/nidavellir/fafner.ctl
@@ -1,0 +1,30 @@
+### Commented entries have reasonable defaults.
+### Uncomment to edit them.
+# Source: <source package name; defaults to package name>
+Section: misc
+Priority: optional
+# Homepage: <enter URL here; no default>
+Standards-Version: 3.9.2
+
+Package: fafner
+# Version: <enter version here; defaults to 1.0>
+# Maintainer: Your Name <yourname@example.com>
+# Pre-Depends: <comma-separated list of packages>
+# Depends: <comma-separated list of packages>
+# Recommends: <comma-separated list of packages>
+# Suggests: <comma-separated list of packages>
+# Provides: <comma-separated list of packages>
+# Replaces: <comma-separated list of packages>
+Architecture: ppc64
+# Multi-Arch: <one of: foreign|same|allowed>
+# Copyright: <copyright file; defaults to GPL2>
+# Changelog: <changelog file; defaults to a generic changelog>
+# Readme: <README.Debian file; defaults to a generic one>
+# Extra-Files: <comma-separated list of additional files for the doc directory>
+# Links: <pair of space-separated paths; First is path symlink points at, second is filename of link>
+# Files: <pair of space-separated paths; First is file to include, second is destination>
+#  <more pairs, if there's more than one file to include. Notice the starting space>
+Description: Fafner
+ Fafner son of Hreidmar was a dwarf with a powerful arm and a fearless soul until
+ he was cursed and became a lindwurm.
+

--- a/debian/nidavellir/hreidmar.ctl
+++ b/debian/nidavellir/hreidmar.ctl
@@ -1,0 +1,29 @@
+### Commented entries have reasonable defaults.
+### Uncomment to edit them.
+# Source: <source package name; defaults to package name>
+Section: misc
+Priority: optional
+# Homepage: <enter URL here; no default>
+Standards-Version: 3.9.2
+
+Package: hreidmar
+# Version: <enter version here; defaults to 1.0>
+# Maintainer: Your Name <yourname@example.com>
+# Pre-Depends: <comma-separated list of packages>
+# Depends: <comma-separated list of packages>
+# Recommends: <comma-separated list of packages>
+# Suggests: <comma-separated list of packages>
+# Provides: <comma-separated list of packages>
+# Replaces: <comma-separated list of packages>
+Architecture: amd64
+# Multi-Arch: <one of: foreign|same|allowed>
+# Copyright: <copyright file; defaults to GPL2>
+# Changelog: <changelog file; defaults to a generic changelog>
+# Readme: <README.Debian file; defaults to a generic one>
+# Extra-Files: <comma-separated list of additional files for the doc directory>
+# Links: <pair of space-separated paths; First is path symlink points at, second is filename of link>
+# Files: <pair of space-separated paths; First is file to include, second is destination>
+#  <more pairs, if there's more than one file to include. Notice the starting space>
+Description: Hreidmar
+ Hreidmar is a dwarf sorcerer and the king of Nidavellir.
+

--- a/debian/nidavellir/regin.ctl
+++ b/debian/nidavellir/regin.ctl
@@ -1,0 +1,29 @@
+### Commented entries have reasonable defaults.
+### Uncomment to edit them.
+# Source: <source package name; defaults to package name>
+Section: misc
+Priority: optional
+# Homepage: <enter URL here; no default>
+Standards-Version: 3.9.2
+
+Package: regin
+# Version: <enter version here; defaults to 1.0>
+# Maintainer: Your Name <yourname@example.com>
+# Pre-Depends: <comma-separated list of packages>
+# Depends: <comma-separated list of packages>
+# Recommends: <comma-separated list of packages>
+# Suggests: <comma-separated list of packages>
+# Provides: <comma-separated list of packages>
+# Replaces: <comma-separated list of packages>
+Architecture: all
+# Multi-Arch: <one of: foreign|same|allowed>
+# Copyright: <copyright file; defaults to GPL2>
+# Changelog: <changelog file; defaults to a generic changelog>
+# Readme: <README.Debian file; defaults to a generic one>
+# Extra-Files: <comma-separated list of additional files for the doc directory>
+# Links: <pair of space-separated paths; First is path symlink points at, second is filename of link>
+# Files: <pair of space-separated paths; First is file to include, second is destination>
+#  <more pairs, if there's more than one file to include. Notice the starting space>
+Description: Regin
+ Regin the son of Hreidmar is the most skillful, and a dwarf of size.
+


### PR DESCRIPTION
This PR tries to solve two issues the current debian fixtures have:

- There are not Packages set to `Architecture: all`.
- There is no repository with the [format](https://wiki.debian.org/DebianRepository/Format#No-Support-for-Architecture-all) `No-Support-for-Architecture: all`

Both are special cases in `pulp_deb` and they should be tested.
 
[noissue]