### PR TITLE
Adjust modular asset

### DIFF
--- a/rpm/assets/modules.yaml
+++ b/rpm/assets/modules.yaml
@@ -13,6 +13,8 @@ data:
   license:
     module:
       - MIT
+    content:
+      - MIT
   profiles:
     default:
       rpms:
@@ -36,6 +38,8 @@ data:
   license:
     module:
       - MIT
+    content:
+      - MIT
   profiles:
     default:
       rpms:
@@ -58,6 +62,8 @@ data:
     A module for the duck 0.8 package
   license:
     module:
+      - MIT
+    content:
       - MIT
   dependencies:
   - buildrequires:
@@ -93,6 +99,8 @@ data:
   license:
     module:
       - MIT
+    content:
+      - MIT
   dependencies:
   - buildrequires:
       walrus: []
@@ -122,6 +130,8 @@ data:
     A module for the duck 0.6 package
   license:
     module:
+      - MIT
+    content:
       - MIT
   dependencies:
   - buildrequires:
@@ -154,6 +164,8 @@ data:
   license:
     module:
       - MIT
+    content:
+      - MIT
   profiles:
     default:
       rpms:
@@ -179,6 +191,8 @@ data:
     RPM artifacts are not libsolv'd on copy.
   license:
     module:
+      - MIT
+    content:
       - MIT
   profiles:
     default:
@@ -206,6 +220,8 @@ data:
   license:
     module:
       - MIT
+    content:
+      - MIT
   profiles:
     default:
       rpms:
@@ -230,6 +246,8 @@ data:
   license:
     module:
       - MIT
+    content:
+      - MIT
   profiles:
     default:
       rpms:
@@ -252,6 +270,8 @@ data:
     A module for the walrus 0.71 package
   license:
     module:
+      - MIT
+    content:
       - MIT
   profiles:
     default:


### PR DESCRIPTION
added `content` license info as required

re: https://github.com/pulp/pulp_rpm/pull/2844

[noissue]