### PR TITLE
Fix CI

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # === Build fixtures (Fedora) =================================================
-FROM registry.fedoraproject.org/fedora:latest AS fedora-build
+FROM registry.fedoraproject.org/fedora:40 AS fedora-build
 
 RUN dnf -yq install \
               fedpkg \
@@ -16,7 +16,7 @@ RUN dnf -yq install \
 
 # the default createrepo_c provided by Fedora has legacy hashes disabled, the one
 # on PyPI does not (because we need it)
-RUN pip install createrepo_c
+RUN pip install createrepo_c==1.2.0
 ADD . /pulp-fixtures
 
 RUN make -C pulp-fixtures all-fedora base_url=http://BASE_URL

--- a/rpm/gen-fixtures.sh
+++ b/rpm/gen-fixtures.sh
@@ -93,14 +93,16 @@ if [ -n "${signing_key:-}" ]; then
         --define '_gpg_name pulp-fixture-signing-key' --addsign
 fi
 checksum_type_default=sha256
+
+args=()
+[ -n "${zchunk:-}" ] && args+=("$zchunk")
+args+=(--general-compress-type gz)
+args+=(--checksum "${checksum_type:-${checksum_type_default}}")
 if test -f "${assets_dir}/comps.xml"; then
-    createrepo_c ${zchunk:-} --general-compress-type gz --checksum "${checksum_type:-${checksum_type_default}}" \
-        --groupfile "$(realpath --relative-to "${working_dir}" "${assets_dir}/comps.xml")" \
-        "${working_dir}"
-else
-    createrepo_c ${zchunk:-} --checksum "${checksum_type:-${checksum_type_default}}" --general-compress-type gz \
-        "${working_dir}"
+    args+=(--groupfile "$(realpath --relative-to "${working_dir}" "${assets_dir}/comps.xml")")
 fi
+args+=("$working_dir")
+createrepo_c "${args[@]}"
 
 if test -f "${assets_dir}/updateinfo.xml"; then
     modifyrepo_c --mdtype updateinfo \


### PR DESCRIPTION
This PR fixes the broken CI build by addressing a ShellCheck warning and pinning Fedora to version 40 and createrepo_c to version 1.2.0, instead of using their latest versions.

A proper fix that enables support for the latest versions is tracked in #256.