### PR TITLE
Fix rpm-complex-pkg repodata including packages not present in output dir

### DIFF
--- a/rpm-new/build_repos.sh
+++ b/rpm-new/build_repos.sh
@@ -24,8 +24,8 @@ createrepo_c \
   --retain-old-md=0 \
   --simple-md-filenames \
   --no-database \
+  --pkglist="$assets_dir/complex_repo_pkglist.txt" \
   "$packages_dir"
-  # --pkglist="$assets_dir/complex_repo_pkglist.txt" \
 
 while IFS= read -r filename
 do


### PR DESCRIPTION
## Summary

`build_repos.sh` runs `createrepo_c` against all files in `assets/packages/` but only copies the subset listed in `complex_repo_pkglist.txt` to the output directory. Previously `assets/packages/` contained only `complex-package-2.3.4-5.el8.x86_64.rpm`, so `createrepo_c` and the pkglist were in sync by accident and the `--pkglist` flag was left commented out.

commit f722825a added `test-package-*.rpm` files to `assets/packages/`. `createrepo_c` then indexed all four packages into the repodata, but only `complex-package` was copied to the output directory. Clients syncing the repository would discover the missing packages in the repodata and attempt to download them, receiving 404 responses.

Uncomment `--pkglist` so `createrepo_c` only indexes the packages that are actually copied to and served from the output directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)